### PR TITLE
Makefile Great Again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
+export FLASK_APP=app
+
+HOST = 127.0.0.1
+PORT = 5000
+OPTS = --reload --debugger --lazy-loader --without-threads
+
 install:
 	pip3 install -r requirements.txt
 
-dev:
-	export FLASK_APP=app
-	export FLASK_ENV=development
-	flask run
+help:
+	flask run --help
 
-server:
-	export FLASK_APP=app
-	flask run
+dev:
+	FLASK_ENV=development flask run --host $(HOST) --port $(PORT) $(OPTS)
 

--- a/README.md
+++ b/README.md
@@ -16,21 +16,21 @@
 #### setup
 `make install`
 
+#### display server options
+`make help`
+
 #### run development server
 `make dev`
-
-#### run production server
-`make server`
 
 #### example request / response
 ```
 $ curl --request POST \
 	 --header "Content-Type: application/json" \
-	 --data "{\"model\":\"mock\",\"tweets\":[{\"text\":\"senPyTweet stinks\", \"tweet_id\":0}, {\"text\":\"crypto is the future\", \"tweet_id\":1}]}" \
+	 --data "{\"model\":\"spacy\",\"tweets\":[{\"text\":\"senPyTweet stinks\", \"tweet_id\":0}, {\"text\":\"crypto is the future\", \"tweet_id\":1}]}" \
 	 http://localhost:5000/score
 
 {
-  "model": "mock",
+  "model": "spacy",
   "tweets": [
     {
       "score": -0.9475799947977066,


### PR DESCRIPTION
Running `make dev` will now run the flask server with the default development settings...
```
$ make dev
FLASK_ENV=development flask run --host 127.0.0.1 --port 5000 --reload --debugger --lazy-loader --without-threads
 * Serving Flask app "app" (lazy loading)
 * Environment: development
 * Debug mode: on
 * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
 * Restarting with stat
 * Debugger is active!
 * Debugger PIN: 603-985-701
```

The server options can now be configured when running `make dev` to overwrite the default settings...
```
$ make dev PORT=8000 OPTS="--eager-loading --with-threads"
FLASK_ENV=development flask run --host 127.0.0.1 --port 8000 --eager-loading --with-threads
 * Serving Flask app "app"
 * Environment: development
 * Debug mode: on
 * Running on http://127.0.0.1:8000/ (Press CTRL+C to quit)
 * Restarting with stat
 * Debugger is active!
 * Debugger PIN: 603-985-701
```

To see all the server options run `make help`