### PR TITLE
senPyDocker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# start from a docker hub python image
+FROM python:3.7
+
+# copy requirements
+COPY requirements.txt /app/
+WORKDIR /app
+
+# install app dependencies
+RUN pip3 install -r requirements.txt
+
+# copy entire project
+COPY . /app
+WORKDIR /app
+
+# start the flask app
+ENTRYPOINT ["flask"]
+CMD ["run", "--host=0.0.0.0", "--eager-loading", "--with-threads"]
+

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,5 @@
 export FLASK_APP=app
 
-HOST = 127.0.0.1
-PORT = 5000
-OPTS = --reload --debugger --lazy-loader --without-threads
-
 install:
 	pip3 install -r requirements.txt
 
@@ -11,5 +7,14 @@ help:
 	flask run --help
 
 dev:
-	FLASK_ENV=development flask run --host $(HOST) --port $(PORT) $(OPTS)
+	FLASK_ENV=development flask run --host 127.0.0.1 --port 5000 --reload --debugger --lazy-loader --without-threads
 
+build:
+	docker build -t sen-py:latest .
+
+run:
+	docker run -p 127.0.0.1:5000:5000/tcp sen-py
+
+prod:
+	docker build -t sen-py:latest .
+	docker run -d -p 127.0.0.1:5000:5000/tcp sen-py

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
  * python >= 3.7.0
  * Flask == 1.0.2
  * spaCy == 2.0.16 (for the default model)
+ * scikit-learn == 0.20.1 (for sklearn models)
 
 #### setup
 `make install`

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
-------------------------------
- senPyTweet
-------------------------------
-### Sentiment API for twitter data
+# senPyTweet - Sentiment API for twitter data
 
-#### features
+## features
  * To use a custom model, add it to the `./senPy/models/` directory. spaCy-based custom models must be trained with a category `'POSITIVE'`. Models must support a `predict` method if they are not spaCy-based.
 
  * The default sentiment model uses spaCy v2's bloom-embedded CNN architecture, trained to the sentiment 140 dataset
+
+## supported models
+* 'spacy' (spaCy v2.0 CNN)
+* 'mock'  (random sentiment)
+* 'scikit/lr' (sklearn logistic regression with L1 penalty)
+* 'scikit/nb' (sklearn multinomial naive bayes)
+
+## getting started
 
 #### dependencies:
  * python >= 3.7.0
@@ -16,18 +21,15 @@
 #### setup
 `make install`
 
-#### display server options
-`make help`
-
 #### run development server
 `make dev`
 
 #### example request / response
 ```
 $ curl --request POST \
-	 --header "Content-Type: application/json" \
-	 --data "{\"model\":\"spacy\",\"tweets\":[{\"text\":\"senPyTweet stinks\", \"tweet_id\":0}, {\"text\":\"crypto is the future\", \"tweet_id\":1}]}" \
-	 http://localhost:5000/score
+   --header "Content-Type: application/json" \
+   --data "{\"model\":\"spacy\",\"tweets\":[{\"text\":\"senPyTweet stinks\", \"tweet_id\":0}, {\"text\":\"crypto is the future\", \"tweet_id\":1}]}" \
+   http://localhost:5000/score
 
 {
   "model": "spacy",
@@ -48,8 +50,10 @@ $ curl --request POST \
 }
 ```
 
-#### supported models:
-* 'spacy' (spaCy v2.0 CNN)
-* 'mock'  (random sentiment)
-* 'scikit/lr' (sklearn logistic regression with L1 penalty)
-* 'scikit/nb' (sklearn multinomial naive bayes)
+## deployment
+#### build docker image
+`make build`
+#### run docker image
+`make run`
+#### deploy new code
+`make prod`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask==1.0.2
 spacy==2.0.18
+scikit-learn==0.21.1


### PR DESCRIPTION
![docker_docker_docker](https://user-images.githubusercontent.com/5237832/58146867-44af3000-7c15-11e9-9cc1-ca27f8b9c25e.jpg)
## Adds docker support to make the VCs go wild

- Dockerfile contains the secret sauce to create a docker image

- Images must be built then ran. Running `make prod` will build the image and start a container.

- The result of `make prod` is the same as `make dev` except senPyTweet is running inside a docker container. Query the API as before for testing.

- You will have to install docker. I'm running Docker 18.09.2.