### PR TITLE
docker tag/push to docker hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ dev:
 	FLASK_ENV=development flask run --host 127.0.0.1 --port 5000 --reload --debugger --lazy-loader --without-threads
 
 build:
-	docker build -t sen-py:latest .
+	docker build -t senpytweet:latest .
 
 run:
-	docker run -p 127.0.0.1:5000:5000/tcp sen-py
+	docker run -p 127.0.0.1:5000:5000/tcp senpytweet
 
 prod:
-	docker build -t sen-py:latest .
-	docker run -d -p 127.0.0.1:5000:5000/tcp sen-py
+	docker tag senpytweet:latest thekeele/senpytweet:latest
+	docker push thekeele/senpytweet


### PR DESCRIPTION
Adds docker commands to put an image in the cloud

build - creates an image named `senpytweet:latest`
prod - tag the source image, `senpytweet:latest` to the target image, `thekeele/senpytweet:latest`
push the image to docker hub